### PR TITLE
Shuffle some sensitive markers around based on variable use

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "tfe_variable" "consul_addr" {
 }
 
 resource "tfe_variable" "consul_root_token" {
-  key             = "consul_addr"
+  key             = "consul_root_token"
   value           = hcp_consul_cluster.partner_hcp.consul_root_token_secret_id
   description     = "Consul Root Token"
   variable_set_id = tfe_variable_set.consul_vs.id

--- a/main.tf
+++ b/main.tf
@@ -47,5 +47,6 @@ resource "tfe_variable" "consul_root_token" {
   value           = hcp_consul_cluster.partner_hcp.consul_root_token_secret_id
   description     = "Consul Root Token"
   variable_set_id = tfe_variable_set.consul_vs.id
+  sensitive       = true
   category        = "terraform"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,10 +20,12 @@ output "consul_config_file" {
 
 output "consul_private_endpoint_url" {
   value = hcp_consul_cluster.partner_hcp.consul_private_endpoint_url
+  description = "the private URL for the consul cluster"
 }
 
 output "consul_public_endpoint_url" {
   value = hcp_consul_cluster.partner_hcp.consul_public_endpoint_url
+  description = "the public URL for the consul cluster"
 }
 
 output "consul_root_token_accessor_id" {
@@ -31,8 +33,8 @@ output "consul_root_token_accessor_id" {
 }
 
 output "consul_root_token_secret_id" {
-  value = hcp_consul_cluster.partner_hcp.consul_root_token_secret_id
-  sensitive = true
+  value = nonsensitive(hcp_consul_cluster.partner_hcp.consul_root_token_secret_id)
+  description = "the consul root token"
 }
 
 output "consul_cluster_id" {


### PR DESCRIPTION
Marked the direct outputs of the consul token as nonsensitive, and marked the varset as sensitive.